### PR TITLE
Add Travis CI test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+dist: trusty
+sudo: required
+
+language: bash
+
+env:
+  global:
+    - IMAGE=pinry/pinry
+    - MOUNT_DIR=/mnt/pinry
+    - HOST_PORT=10000
+    - GUEST_PORT=80
+  matrix:
+    - TARGET=private PRIVATE=true
+    - TARGET=allow_new_registrations ALLOW_NEW_REGISTRATIONS=true
+
+install:
+  - docker build -t "$IMAGE" .
+  - docker inspect "$IMAGE"
+  - docker images
+
+before_script:
+  - sudo mkdir -p $MOUNT_DIR
+
+script:
+  - tests/test.sh $TARGET

--- a/tests/http_status_code.sh
+++ b/tests/http_status_code.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+  cat <<EOL
+USAGE: $(basename $0) url
+OPTIONS:
+  -h, --help
+EOL
+    exit 1
+}
+
+main() {
+    local argc=0
+    local argv=()
+
+    while [ $# -gt 0 ]; do
+        case $1 in
+            -h|--help)
+                usage
+                ;;
+            *)
+                argc=`expr $argc + 1`
+                argv+=($1)
+                ;;
+        esac
+  
+        shift
+    done
+
+    if [ $argc -lt 1 ]; then
+        echo "Too few arguments"
+        exit 1
+    fi
+
+    url=${argv[0]}
+    http_status_code=`curl -s -w "%{http_code}" -o /dev/null $url`
+    echo $http_status_code
+}
+
+main $*

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+home_url="http://localhost:$HOST_PORT/"
+new_registration_url="http://localhost:$HOST_PORT/register/"
+
+echo "Starting container."
+
+docker run -d=true \
+  -p=$HOST_PORT:$GUEST_PORT \
+  -v=$MOUNT_DIR:/data \
+  -e ALLOW_NEW_REGISTRATIONS="$ALLOW_NEW_REGISTRATIONS" \
+  -e PRIVATE="$PRIVATE" \
+  "$IMAGE" \
+  /start
+
+sleep 10
+
+case $1 in
+  private)
+    status_code_of_home=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $home_url`
+    status_code_of_new_registration=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $new_registration_url`
+    [ "$status_code_of_home" = "302" ] && [ "$status_code_of_new_registration" = "302" ] && exit 0
+    ;;
+  allow_new_registrations)
+    status_code_of_home=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $home_url`
+    status_code_of_new_registration=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $new_registration_url`
+    [ "$status_code_of_home" = "200" ] && [ "$status_code_of_new_registration" = "200" ] && exit 0
+    ;;
+  *)
+    echo "$0 $1: invalid option."
+    exit 1
+esac
+
+exit 1

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -17,15 +17,16 @@ docker run -d=true \
 
 sleep 10
 
+# Get status codes
+status_code_of_home=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $home_url`
+status_code_of_new_registration=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $new_registration_url`
+
+# Check status codes
 case $1 in
   private)
-    status_code_of_home=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $home_url`
-    status_code_of_new_registration=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $new_registration_url`
     [ "$status_code_of_home" = "302" ] && [ "$status_code_of_new_registration" = "302" ] && exit 0
     ;;
   allow_new_registrations)
-    status_code_of_home=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $home_url`
-    status_code_of_new_registration=`$TRAVIS_BUILD_DIR/tests/http_status_code.sh $new_registration_url`
     [ "$status_code_of_home" = "200" ] && [ "$status_code_of_new_registration" = "200" ] && exit 0
     ;;
   *)


### PR DESCRIPTION
I added some lightweight tests that check pinry's HTTP status code in container.
To run these tests on Travis CI, we need to do follow steps.

Step 1: Sign in to https://travis-ci.org/ with GitHub account.
Step 2: Sync account.
Step 3: Activate yourname/docker-pinry.