### PR TITLE
Add creating super user option

### DIFF
--- a/scripts/start
+++ b/scripts/start
@@ -50,6 +50,15 @@ fi
 # Fix all settings after all commands are run
 chown -R www-data:www-data /data
 
+# Create superuser
+if [ "$SUPER_USER_NAME" ] && [ "$SUPER_USER_PASSWORD" ]
+then
+    cd /srv/www/pinry
+    cat << EOS | bin/python manage.py shell --settings=pinry.settings.production
+from django.contrib.auth.models import User
+User.objects.create_superuser('$SUPER_USER_NAME', '$SUPER_USER_EMAIL', '$SUPER_USER_PASSWORD')
+EOS
+fi
 
 /usr/bin/supervisord
 


### PR DESCRIPTION
I added option to create super user when docker is up.
We can use this option as follows.

```shell
sudo docker run -d=true \
    -e SUPER_USER_NAME=your_awesome_name \
    -e SUPER_USER_PASSWORD=your_awesome_password \
    -e SUPER_USER_EMAIL=your_awesome_email@example.com \
    -p=10000:80 \
    -v=/mnt/pinry:/data \
    pinry/pinry \
    /start
```

`SUPER_USER_NAME` and `SUPER_USER_PASSWORD` are required to create super user.
`SUPER_USER_EMAIL` is optional.